### PR TITLE
fix(hm-git): add clear command before setting EDITOR

### DIFF
--- a/hosts/shared/home-manager/git/default.nix
+++ b/hosts/shared/home-manager/git/default.nix
@@ -9,7 +9,7 @@
       - key: <c-g>
         description: Pick LLM commit
         loadingText: "waiting for LLM to generate commit messages..."
-        command: export EDITOR=nvim && commit-oracle.sh
+        command: clear && export EDITOR=nvim && commit-oracle.sh
         context: files
         subprocess: true
     '';


### PR DESCRIPTION
Ensures the terminal is cleared before exporting EDITOR and executing commit-oracle.sh.